### PR TITLE
include small_string instead of stdb_string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,16 +66,16 @@ if (FBE_USING_STD_VECTOR)
 endif()
 
 option(FBE_USING_SEASTAR_STRING "using seastar string" OFF)
-option(FBE_USING_MEMORY_STRING "using memory string" OFF)
+option(FBE_USING_SMALL_STRING "using memory string" OFF)
 if (FBE_USING_SEASTAR_STRING)
   add_definitions(-DUSING_SEASTAR_STRING)
-elseif(FBE_USING_MEMORY_STRING)
-  add_definitions(-DUSING_MEMORY_STRING)
+elseif(FBE_USING_SMALL_STRING)
+  add_definitions(-DUSING_SMALL_STRING)
 endif()
 
-option(FBE_USING_MEMORY_ARENA_STRING "using memory arena string" OFF)
-if (FBE_USING_MEMORY_ARENA_STRING)
-  add_definitions(-DUSING_MEMORY_ARENA_STRING)
+option(FBE_USING_SMALL_ARENA_STRING "using memory arena string" OFF)
+if (FBE_USING_SMALL_ARENA_STRING)
+  add_definitions(-DUSING_SMALL_ARENA_STRING)
 endif()
 
 # System directories

--- a/include/fbe.h
+++ b/include/fbe.h
@@ -42,8 +42,6 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
-#include "memory/string/string.hpp"
-
 // file and directory section
 namespace fs = std::filesystem;
 
@@ -74,10 +72,10 @@ inline auto read_all(const fs::path& path) -> std::string {
     if (!file.is_open())
         return { };
     // Read contents
-    stdb::memory::string content{std::istreambuf_iterator<char>{file}, std::istreambuf_iterator<char>()};
+    std::string content{std::istreambuf_iterator<char>{file}, std::istreambuf_iterator<char>()};
     // Close the file
     file.close();
-    return content.toStdString();
+    return content;
 }
 
 inline void write_all(const fs::path& path, const std::string& content) {

--- a/include/generator_cpp_fixture.h
+++ b/include/generator_cpp_fixture.h
@@ -58,11 +58,11 @@ namespace pmr = std::pmr;
 #if defined(USING_SEASTAR_STRING)
 #include <seastar/core/sstring.hh>
 #elif defined(USING_SMALL_STRING)
-#include "string/string.hpp"
+#include "string/small_string.hpp"
 #endif
 
 #if defined(USING_SMALL_ARENA_STRING)
-#include "string/arena_string.hpp"
+#include "string/small_string.hpp"
 #endif
 
 namespace FBE {
@@ -5765,9 +5765,9 @@ struct KeyWriter<TWriter, char>
 
 #if defined(USING_SEASTAR_STRING) || defined(USING_SMALL_STRING)
 template <class TWriter>
-struct KeyWriter<TWriter, std::string>
+struct KeyWriter<TWriter, std::string_view>
 {
-    static bool to_json_key(TWriter& writer, const std::string& key)
+    static bool to_json_key(TWriter& writer, const std::string_view& key)
     {
         return writer.Key(key);
     }
@@ -5779,7 +5779,7 @@ struct KeyWriter<TWriter, FBEString>
 {
     static bool to_json_key(TWriter& writer, const FBEString& key)
     {
-        return writer.Key(key.c_str());
+        return writer.Key(key);
     }
 };
 
@@ -5788,7 +5788,7 @@ struct KeyWriter<TWriter, ArenaString>
 {
     static bool to_json_key(TWriter& writer, const ArenaString& key)
     {
-        return writer.Key(key.c_str());
+        return writer.Key(key);
     }
 };
 
@@ -5953,9 +5953,9 @@ struct ValueWriter<TWriter, FBE::uuid_t>
 
 #if defined(USING_SEASTAR_STRING) || defined(USING_SMALL_STRING)
 template <class TWriter>
-struct ValueWriter<TWriter, std::string>
+struct ValueWriter<TWriter, std::string_view>
 {
-    static bool to_json(TWriter& writer, const std::string& value, bool scope = true)
+    static bool to_json(TWriter& writer, const std::string_view& value, bool scope = true)
     {
         return writer.String(value);
     }
@@ -5967,7 +5967,7 @@ struct ValueWriter<TWriter, FBEString>
 {
     static bool to_json(TWriter& writer, const FBEString& value, bool scope = true)
     {
-        return writer.String(value.c_str());
+        return writer.String(value);
     }
 };
 
@@ -5976,7 +5976,7 @@ struct ValueWriter<TWriter, ArenaString>
 {
     static bool to_json(TWriter& writer, const ArenaString& value, bool scope = true)
     {
-        return writer.String(value.c_str());
+        return writer.String(value);
     }
 };
 

--- a/include/generator_cpp_fixture.h
+++ b/include/generator_cpp_fixture.h
@@ -4388,7 +4388,7 @@ public:
     size_t fbe_allocation_size(const char (&data)[N]) const noexcept { return 4 + N; }
     template <size_t N>
     size_t fbe_allocation_size(const std::array<char, N>& data) const noexcept { return 4 + N; }
-    size_t fbe_allocation_size(const std::string& value) const noexcept { return 4 + value.size(); }
+    size_t fbe_allocation_size(const FBEString& value) const noexcept { return 4 + value.size(); }
 
     // Get the field offset
     size_t fbe_offset() const noexcept { return _offset; }

--- a/include/generator_cpp_fixture.h
+++ b/include/generator_cpp_fixture.h
@@ -57,11 +57,11 @@ namespace pmr = std::pmr;
 
 #if defined(USING_SEASTAR_STRING)
 #include <seastar/core/sstring.hh>
-#elif defined(USING_MEMORY_STRING)
+#elif defined(USING_SMALL_STRING)
 #include "string/string.hpp"
 #endif
 
-#if defined(USING_MEMORY_ARENA_STRING)
+#if defined(USING_SMALL_ARENA_STRING)
 #include "string/arena_string.hpp"
 #endif
 
@@ -76,14 +76,14 @@ namespace FBE {
 
     #if defined(USING_SEASTAR_STRING)
     using FBEString = seastar::sstring;
-    #elif defined(USING_MEMORY_STRING)
-    using FBEString = stdb::memory::string;
+    #elif defined(USING_SMALL_STRING)
+    using FBEString = stdb::memory::small_byte_string;
     #else
     using FBEString = std::string;
     #endif
 
-    #if defined(USING_MEMORY_ARENA_STRING)
-    using ArenaString = stdb::memory::arena_string;
+    #if defined(USING_SMALL_ARENA_STRING)
+    using ArenaString = stdb::memory::pmr::small_byte_string;
     #else
     using ArenaString = pmr::string;
     #endif
@@ -5763,7 +5763,7 @@ struct KeyWriter<TWriter, char>
     }
 };
 
-#if defined(USING_SEASTAR_STRING) || defined(USING_MEMORY_STRING)
+#if defined(USING_SEASTAR_STRING) || defined(USING_SMALL_STRING)
 template <class TWriter>
 struct KeyWriter<TWriter, std::string>
 {
@@ -5951,7 +5951,7 @@ struct ValueWriter<TWriter, FBE::uuid_t>
     }
 };
 
-#if defined(USING_SEASTAR_STRING) || defined(USING_MEMORY_STRING)
+#if defined(USING_SEASTAR_STRING) || defined(USING_SMALL_STRING)
 template <class TWriter>
 struct ValueWriter<TWriter, std::string>
 {
@@ -6137,7 +6137,7 @@ bool from_json_key(const TJson& json, T& key)
     return KeyReader<TJson, T>::from_json_key(json, key);
 }
 
-#if defined(USING_SEASTAR_STRING) || defined(USING_MEMORY_STRING)
+#if defined(USING_SEASTAR_STRING) || defined(USING_SMALL_STRING)
 template <class TJson>
 struct KeyReader<TJson, std::string>
 {
@@ -6464,7 +6464,7 @@ struct ValueReader<TJson, FBE::uuid_t>
     }
 };
 
-#if defined(USING_SEASTAR_STRING) || defined(USING_MEMORY_STRING)
+#if defined(USING_SEASTAR_STRING) || defined(USING_SMALL_STRING)
 template <class TJson>
 struct ValueReader<TJson, std::string>
 {

--- a/proto/fbe.h
+++ b/proto/fbe.h
@@ -60,12 +60,12 @@ namespace pmr = std::pmr;
 
 #if defined(USING_SEASTAR_STRING)
 #include <seastar/core/sstring.hh>
-#elif defined(USING_MEMORY_STRING)
-#include "string/string.hpp"
+#elif defined(USING_SMALL_STRING)
+#include "string/small_string.hpp"
 #endif
 
-#if defined(USING_MEMORY_ARENA_STRING)
-#include "string/arena_string.hpp"
+#if defined(USING_SMALL_ARENA_STRING)
+#include "string/small_string.hpp"
 #endif
 
 namespace FBE {
@@ -79,14 +79,14 @@ namespace FBE {
 
     #if defined(USING_SEASTAR_STRING)
     using FBEString = seastar::sstring;
-    #elif defined(USING_MEMORY_STRING)
-    using FBEString = stdb::memory::string;
+    #elif defined(USING_SMALL_STRING)
+    using FBEString = stdb::memory::small_byte_string;
     #else
     using FBEString = std::string;
     #endif
 
-    #if defined(USING_MEMORY_ARENA_STRING)
-    using ArenaString = stdb::memory::arena_string;
+    #if defined(USING_SMALL_ARENA_STRING)
+    using ArenaString = stdb::memory::pmr::small_byte_string;
     #else
     using ArenaString = pmr::string;
     #endif

--- a/smoke_tests/CMakeLists.txt
+++ b/smoke_tests/CMakeLists.txt
@@ -11,7 +11,7 @@
 # pmr don't work with --final, ptr don't work with --final and --json
 # so the 4,6,8 are not currently supported. 
 
-add_definitions(-DUSING_MEMORY_ARENA_STRING -DCROSS_THREAD_CHECKING)
+add_definitions(-DUSING_SMALL_ARENA_STRING)
 
 SET(FBEC_COMMAND "${CMAKE_BINARY_DIR}/fbec")
 set(FBE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/generated")

--- a/smoke_tests/CMakeLists.txt
+++ b/smoke_tests/CMakeLists.txt
@@ -11,7 +11,7 @@
 # pmr don't work with --final, ptr don't work with --final and --json
 # so the 4,6,8 are not currently supported. 
 
-add_definitions(-DUSING_SMALL_ARENA_STRING)
+add_definitions(-DUSING_SMALL_ARENA_STRING -DUSING_SMALL_STRING)
 
 SET(FBEC_COMMAND "${CMAKE_BINARY_DIR}/fbec")
 set(FBE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/generated")

--- a/smoke_tests/smoke_normal.cc
+++ b/smoke_tests/smoke_normal.cc
@@ -68,11 +68,11 @@ struct TypeHelper<int128_t>
 };
 
 template <>
-struct TypeHelper<std::string>
+struct TypeHelper<FBEString>
 {
     using Type = String;
     using Model = StringModel;
-    static auto random_value() -> std::string { return "asdf"; }
+    static auto random_value() -> FBEString { return "asdf"; }
 };
 
 template <>
@@ -83,7 +83,7 @@ struct TypeHelper<BufferT>
     static auto random_value() -> BufferT { return BufferT{"asdfqwer"}; }
 };
 
-TEST_CASE_TEMPLATE("Smoke::serialize::normal", T, bool, int8_t, int16_t, int32_t, int64_t, int128_t, std::string,
+TEST_CASE_TEMPLATE("Smoke::serialize::normal", T, bool, int8_t, int16_t, int32_t, int64_t, int128_t, FBEString,
                    BufferT) {
     using Helper = TypeHelper<T>;
     using Model = Helper::Model;

--- a/smoke_tests/smoke_normal_pmr.cc
+++ b/smoke_tests/smoke_normal_pmr.cc
@@ -7,6 +7,7 @@
 #include "fbe.h"
 #include "smoke_normal_pmr_models.h"
 #include "string/arena_string.hpp"
+#include "string/small_string.hpp"
 
 using int128_t = __int128;
 using stdb::memory::Arena;
@@ -68,7 +69,7 @@ struct TypeHelper<int128_t>
 };
 
 template <>
-struct TypeHelper<arena_string>
+struct TypeHelper<stdb::memory::pmr::small_byte_string>
 {
     using Type = String;
     using Model = StringModel;
@@ -87,7 +88,7 @@ struct TypeHelper<BufferT>
     }
 };
 
-TEST_CASE_TEMPLATE("Smoke::serialize::normal_pmr", T, bool, int8_t, int16_t, int32_t, int64_t, int128_t, arena_string,
+TEST_CASE_TEMPLATE("Smoke::serialize::normal_pmr", T, bool, int8_t, int16_t, int32_t, int64_t, int128_t, stdb::memory::pmr::small_byte_string,
                    BufferT) {
     using Helper = TypeHelper<T>;
     using Model = Helper::Model;

--- a/smoke_tests/smoke_normal_pmr.cc
+++ b/smoke_tests/smoke_normal_pmr.cc
@@ -4,6 +4,7 @@
 
 #include "arena/arena.hpp"
 #include "doctest/doctest.h"
+#include "fbe.h"
 #include "smoke_normal_pmr_models.h"
 #include "string/arena_string.hpp"
 
@@ -71,7 +72,7 @@ struct TypeHelper<arena_string>
 {
     using Type = String;
     using Model = StringModel;
-    static auto random_value(Arena& arena) -> arena_string {
+    static auto random_value(Arena& arena) -> ArenaString{
         return {"asdfqwerzxcvasdfqwerzxcvasdfqwerzxcv", arena.get_memory_resource()};
     };
 };
@@ -82,7 +83,7 @@ struct TypeHelper<BufferT>
     using Type = Bytes;
     using Model = BytesModel;
     static auto random_value(Arena& arena) -> BufferT {
-        return BufferT{arena_string{"asdfqwer", arena.get_memory_resource()}};
+        return BufferT{ArenaString{"asdfqwer", arena.get_memory_resource()}};
     }
 };
 
@@ -135,14 +136,14 @@ TEST_CASE("Smoke::serialize::normal_pmr::nested") {
     obj_1.inners.emplace_back(100);
 
     obj_1.values.emplace_back(10);
-    obj_1.values.emplace_back(arena_string{"adsf", arena.get_memory_resource()});
+    obj_1.values.emplace_back(ArenaString{"adsf", arena.get_memory_resource()});
     obj_1.values.emplace_back(Inner{12});
 
-    obj_1.bytes_map.emplace(arena_string{"bytes", arena.get_memory_resource()},
-                            BufferT{arena_string{"qwer", arena.get_memory_resource()}});
+    obj_1.bytes_map.emplace(ArenaString{"bytes", arena.get_memory_resource()},
+                            BufferT{ArenaString{"qwer", arena.get_memory_resource()}});
 
-    obj_1.value_map.emplace(arena_string{"value", arena.get_memory_resource()},
-                            arena_string{"", arena.get_memory_resource()});
+    obj_1.value_map.emplace(ArenaString{"value", arena.get_memory_resource()},
+                            ArenaString{"", arena.get_memory_resource()});
 
     OuterModel model_1{};
     model_1.serialize(obj_1, arena.get_memory_resource());

--- a/smoke_tests/smoke_ptr_pmr.cc
+++ b/smoke_tests/smoke_ptr_pmr.cc
@@ -2,6 +2,7 @@
 
 #include "arena/arena.hpp"
 #include "doctest/doctest.h"
+#include "fbe.h"
 #include "smoke_ptr_ptr_pmr.h"
 #include "smoke_ptr_ptr_pmr_models.h"
 
@@ -69,7 +70,7 @@ struct TypeHelper<arena_string>
 {
     using Type = String;
     using Model = StringModel;
-    static auto random_value(Arena& arena) -> arena_string {
+    static auto random_value(Arena& arena) -> ArenaString{
         return {"asdfqwerzxcvasdfqwerzxcvasdfqwerzxcv", arena.get_memory_resource()};
     };
 };
@@ -146,11 +147,11 @@ TEST_CASE("Smoke::serialize::ptr_pmr::nested") {
     // obj_1.inner_ptrs.emplace_back(arena.Create<Inner>(11));
 
     obj_1.values.emplace_back(10);
-    obj_1.values.emplace_back(arena_string{"adsf", arena.get_memory_resource()});
+    obj_1.values.emplace_back(ArenaString{"adsf", arena.get_memory_resource()});
     obj_1.values.emplace_back(Inner{12});
 
-    obj_1.bytes_map.emplace(arena_string{"bytes", arena.get_memory_resource()},
-                            BufferT{arena_string{"qwer", arena.get_memory_resource()}});
+    obj_1.bytes_map.emplace(String{"bytes", arena.get_memory_resource()},
+                            BufferT{ArenaString{"qwer", arena.get_memory_resource()}});
 
     obj_1.value_map.emplace(arena_string{"value", arena.get_memory_resource()},
                             arena_string{"", arena.get_memory_resource()});

--- a/smoke_tests/smoke_ptr_pmr.cc
+++ b/smoke_tests/smoke_ptr_pmr.cc
@@ -5,6 +5,7 @@
 #include "fbe.h"
 #include "smoke_ptr_ptr_pmr.h"
 #include "smoke_ptr_ptr_pmr_models.h"
+#include "string/small_string.hpp"
 
 using int128_t = __int128;
 using stdb::memory::Arena;
@@ -126,6 +127,7 @@ TEST_CASE_TEMPLATE("Smoke::serialize::ptr_pmr", T, bool, int8_t, int16_t, int32_
 
 TEST_CASE("Smoke::serialize::ptr_pmr::nested") {
     Arena arena{Arena::Options::GetDefaultOptions()};
+    using String = stdb::memory::pmr::small_byte_string;
 
     Outer obj_1{arena.get_memory_resource()};
     obj_1.inner.value = 10;
@@ -153,8 +155,8 @@ TEST_CASE("Smoke::serialize::ptr_pmr::nested") {
     obj_1.bytes_map.emplace(String{"bytes", arena.get_memory_resource()},
                             BufferT{ArenaString{"qwer", arena.get_memory_resource()}});
 
-    obj_1.value_map.emplace(arena_string{"value", arena.get_memory_resource()},
-                            arena_string{"", arena.get_memory_resource()});
+    obj_1.value_map.emplace(String{"value", arena.get_memory_resource()},
+                            String{"", arena.get_memory_resource()});
 
     OuterModel model_1{};
     model_1.serialize(obj_1, arena.get_memory_resource());

--- a/source/fbe.l
+++ b/source/fbe.l
@@ -18,8 +18,8 @@ E [Ee][+-]?{D}+
 #include "generator_swift.h"
 
 #include <optparse/optparse.hpp>
-#include <string/string.hpp>
 #include <iostream>
+#include <string>
 
 void yycount();
 int yychar(char c);


### PR DESCRIPTION
1. use small_byte_string to replace all stdb_string
2. use pmr::small_byte_string to replace all arena_string
3. remove cstr std::string from FBEString.c_str(), because byte_string is without NullTerminated.
4. change the flag name
5. fix some legacy problems of fbe.l