### PR TITLE
fix: pass data()+size() to rapidjson String() for buffer_t

### DIFF
--- a/include/generator_cpp_fixture.h
+++ b/include/generator_cpp_fixture.h
@@ -7865,7 +7865,8 @@ struct ValueWriter<TWriter, buffer_t>
 {
     static bool to_json(TWriter& writer, const buffer_t& values, bool scope = true)
     {
-        return writer.String(values.base64encode());
+        auto encoded = values.base64encode();
+        return writer.String(encoded.data(), static_cast<rapidjson::SizeType>(encoded.size()));
     }
 };
 

--- a/proto/fbe_json.h
+++ b/proto/fbe_json.h
@@ -314,7 +314,8 @@ struct ValueWriter<TWriter, buffer_t>
 {
     static bool to_json(TWriter& writer, const buffer_t& values, bool scope = true)
     {
-        return writer.String(values.base64encode());
+        auto encoded = values.base64encode();
+        return writer.String(encoded.data(), static_cast<rapidjson::SizeType>(encoded.size()));
     }
 };
 


### PR DESCRIPTION
## Summary

- `ValueWriter<TWriter, buffer_t>::to_json` was calling `writer.String(values.base64encode())`, passing a `std::string` to `rapidjson::Writer::String` whose only overloads take `const Ch*`/`(const Ch*, SizeType)`. Release builds with `-Werror` (and any consumer that actually instantiates the buffer_t JSON serializer) refuse to compile: "no matching member function for call to 'String'".
- Switch to the `(data(), size())` overload with an explicit `rapidjson::SizeType` cast, in both the generator fixture and the already-generated `proto/fbe_json.h` so the shipped proto sample stays consistent.

## Details

Downstream crash example (clapdb, C++23 clang 21 `-O3 -Werror`):

```
gen/metas/generated/fbe_json.h:317:23: error: no matching member function for call to 'String'
  return writer.String(values.base64encode());
         ~~~~~~~^~~~~~
thirdparty/rapidjson/include/rapidjson/writer.h:260:10: note: candidate function not viable:
  no known conversion from 'std::string' to 'const Ch *const' for 1st argument
thirdparty/rapidjson/include/rapidjson/writer.h:204:10: note: candidate function not viable:
  requires at least 2 arguments, but 1 was provided
```

`rapidjson::SizeType` comes from `rapidjson/rapidjson.h` and is already in scope wherever `rapidjson::Writer` is visible, so no new include is needed.

## Test plan

- [x] Local C++23 release build of a consumer (clapdb) that instantiates `FBE::JSON::to_json<..., buffer_t>` now compiles cleanly.
- [x] `proto/fbe_json.h` diff is byte-identical to what a fresh \`fbec\` run would emit from the updated fixture, so regenerating won't flip it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)